### PR TITLE
fix(common): add default if we use optional_nullable

### DIFF
--- a/rust/_common/models.j2
+++ b/rust/_common/models.j2
@@ -34,7 +34,7 @@ pub struct {{ m::model_name(name = model.object.name) }} {
     {% elif not property.nullable and property.required and property.type == "array" and property.model.type == "object" %}
     #[validate]
     {% endif %}
-    #[serde(rename = "{{ property.name }}"{% if not property.required and property.nullable %}, deserialize_with = "optional_nullable"{% elif not property.required %}, skip_serializing_if = "Option::is_none"{% endif %})]
+    #[serde(rename = "{{ property.name }}"{% if not property.required and property.nullable %}, default, deserialize_with = "optional_nullable"{% elif not property.required %}, skip_serializing_if = "Option::is_none"{% endif %})]
     pub {{ m::property_name(name = property.name) }}: {% if not property.required %}Option<{% endif %}{{ m::type(property = property) }}{% if not property.required %}>{% endif %},
     {% endfor %}
 }


### PR DESCRIPTION
When we use optional_nullable we need to add default to make it usable with missing fields