### PR TITLE
fix(common): transform enums to camel case

### DIFF
--- a/rust/_common/models.j2
+++ b/rust/_common/models.j2
@@ -66,7 +66,7 @@ impl {{ m::model_name(name = model.object.name) }} { {# if sort required first #
 {%- endif %}
 pub enum {{ m::model_name(name = model.enum.name) }}Variant {
     {% for option in model.enum.options -%}
-    {% if option == option | when_numeric(prefix="n") | camelcase | upper -%}
+    {% if option == option | when_numeric(prefix="n") | pascalcase -%}
     {{ option }},
     {%- elif model.enum.type == "number" %}
     {{ m::enum_variant(name = option, base = m::model_name(name = model.enum.name) ) }} = {{ option }},
@@ -81,7 +81,7 @@ impl std::string::ToString for {{ m::model_name(name = model.enum.name) }}Varian
     fn to_string(&self) -> String {
         match self {
             {% for option in model.enum.options -%}
-            Self::{% if option == option | when_numeric(prefix="n") | camelcase | upper -%}
+            Self::{% if option == option | when_numeric(prefix="n") | pascalcase -%}
             {{ option }}
             {%- else %}
             {{ m::enum_variant(name = option, base = m::model_name(name = model.enum.name)) }}
@@ -97,7 +97,7 @@ impl std::str::FromStr for {{ m::model_name(name = model.enum.name) }}Variant {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             {% for option in model.enum.options -%}
-            "{{ option }}" => Ok(Self::{% if option == option | when_numeric(prefix="n") | camelcase | upper -%}
+            "{{ option }}" => Ok(Self::{% if option == option | when_numeric(prefix="n") | pascalcase -%}
             {{ option }}
             {%- else %}
             {{ m::enum_variant(name = option, base = m::model_name(name = model.enum.name)) }}

--- a/rust/_common/models.j2
+++ b/rust/_common/models.j2
@@ -66,7 +66,7 @@ impl {{ m::model_name(name = model.object.name) }} { {# if sort required first #
 {%- endif %}
 pub enum {{ m::model_name(name = model.enum.name) }}Variant {
     {% for option in model.enum.options -%}
-    {% if option == option | when_numeric(prefix="n") | upper -%}
+    {% if option == option | when_numeric(prefix="n") | camelcase | upper -%}
     {{ option }},
     {%- elif model.enum.type == "number" %}
     {{ m::enum_variant(name = option, base = m::model_name(name = model.enum.name) ) }} = {{ option }},
@@ -81,7 +81,7 @@ impl std::string::ToString for {{ m::model_name(name = model.enum.name) }}Varian
     fn to_string(&self) -> String {
         match self {
             {% for option in model.enum.options -%}
-            Self::{% if option == option | when_numeric(prefix="n") | upper -%}
+            Self::{% if option == option | when_numeric(prefix="n") | camelcase | upper -%}
             {{ option }}
             {%- else %}
             {{ m::enum_variant(name = option, base = m::model_name(name = model.enum.name)) }}
@@ -97,7 +97,7 @@ impl std::str::FromStr for {{ m::model_name(name = model.enum.name) }}Variant {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             {% for option in model.enum.options -%}
-            "{{ option }}" => Ok(Self::{% if option == option | when_numeric(prefix="n") | upper -%}
+            "{{ option }}" => Ok(Self::{% if option == option | when_numeric(prefix="n") | camelcase | upper -%}
             {{ option }}
             {%- else %}
             {{ m::enum_variant(name = option, base = m::model_name(name = model.enum.name)) }}

--- a/tests/rust-axum/src/main.rs
+++ b/tests/rust-axum/src/main.rs
@@ -29,7 +29,7 @@ mod handler {
         let _result = db.get_smth().await;
 
         api::endpoint::LivezListResponse::Status200(api::model::ServiceStatus {
-            status: api::model::ServiceStatusStatusVariant::UP,
+            status: api::model::ServiceStatusStatusVariant::Up,
             components: vec![],
         })
     }
@@ -38,7 +38,7 @@ mod handler {
         let _result = db.get_smth().await;
 
         api::endpoint::ReadyzListResponse::Status200(api::model::ServiceStatus {
-            status: api::model::ServiceStatusStatusVariant::UP,
+            status: api::model::ServiceStatusStatusVariant::Up,
             components: vec![],
         })
     }

--- a/tests/rust/src/main.rs
+++ b/tests/rust/src/main.rs
@@ -29,7 +29,7 @@ mod handler {
         let _result = db.get_smth().await;
 
         api::endpoint::LivezListResponse::Status200(api::model::ServiceStatus {
-            status: api::model::ServiceStatusStatusVariant::UP,
+            status: api::model::ServiceStatusStatusVariant::Up,
             components: vec![],
         })
     }
@@ -38,7 +38,7 @@ mod handler {
         let _result = db.get_smth().await;
 
         api::endpoint::ReadyzListResponse::Status200(api::model::ServiceStatus {
-            status: api::model::ServiceStatusStatusVariant::UP,
+            status: api::model::ServiceStatusStatusVariant::Up,
             components: vec![],
         })
     }


### PR DESCRIPTION
This fixes issues with `SHAPED-AS-SUCH` enum options. Also it increases readability with camel case.