### PR TITLE
WIP: fix: import date_time in clients if need

### DIFF
--- a/rust/_common/macros.j2
+++ b/rust/_common/macros.j2
@@ -18,6 +18,12 @@
 {%- endfor %}
 {%- endmacro has_format %}
 
+{% macro has_format_query(format, models) -%}
+    {% for model in models | filter(attribute="model") -%}
+            {% if model.model.validation and model.model.validation.format and model.model.validation.format == format %}1{% endif %}
+    {%- endfor %}
+{%- endmacro has_format_query %}
+
 {% macro model_name(name) %}{% filter nospaces %}
     {{ name  }}
 {% endfilter %}{% endmacro model_name %}

--- a/rust/client/endpoints.j2
+++ b/rust/client/endpoints.j2
@@ -9,6 +9,22 @@ use super::{ClientError, ApiError};
 use std::future::Future;
 use std::pin::Pin;
 
+{% set_global use_datetime = false %}
+{% for tag in tags %}
+    {% set allowed_operations = e::allowed_operations(endpoints=tag.endpoints, options=options) | split(pat=" ") %}
+    {% set filtered_endpoints = tag.endpoints | filter_inarray(attribute="operation", values=allowed_operations) %}
+    {% for endpoint in filtered_endpoints %}
+        {%- if endpoint.parameters.query | length > 0 %}
+            {% if m::has_format_query(format="date-time", models=endpoint.parameters.query) %}
+                {% set_global use_datetime = true %}
+            {% endif %}
+        {% endif %}
+    {% endfor %}
+{% endfor %}
+{% if use_datetime %}
+    use chrono::{DateTime, Utc};
+{% endif %}
+
 {% for tag in tags %}
 {% set allowed_operations = e::allowed_operations(endpoints=tag.endpoints, options=options) | split(pat=" ") %}
 {% set filtered_endpoints = tag.endpoints | filter_inarray(attribute="operation", values=allowed_operations) %}
@@ -21,7 +37,7 @@ use std::pin::Pin;
 #[derive(Debug)]
 pub enum {{ endpoint.operation | pascalcase }}Error {
 	{% for response in endpoint.responses.all  %}
-    {% if response != endpoint.responses.success %}	
+    {% if response != endpoint.responses.success %}
 	Error{{ response.statusCode }}({%- filter trim_start_matches(pat=", ") -%}
 		{%- if not response.models -%}
 		{%- else -%}
@@ -41,7 +57,7 @@ impl ApiError for {{ endpoint.operation | pascalcase }}Error {
 				{% if response != endpoint.responses.success %}
 				{{ response.statusCode }} => {% if response.headers | default(value=[]) | filter_not_inarray(attribute="name", values=skipped_headers) | length > 0 %} {
 					let headers = response.headers().clone();
-					
+
 					{% if not response.models %}
 					Some(Self::Error{{ response.statusCode }}(headers))
 					{% else %}
@@ -87,7 +103,7 @@ impl {{ endpoint.operation | pascalcase }}Headers {
 			{% endif %}
 			{% endfor -%}
 		]
-		.iter()	
+		.iter()
 		.filter_map(|f| f.clone())
 		.collect::<Vec<_>>()
 	}
@@ -97,7 +113,7 @@ impl {{ endpoint.operation | pascalcase }}Headers {
 {% if not endpoint.responses.success.models or endpoint.responses.success.models.default.contentType is not starting_with("application/json") %}
 #[derive(Debug)]
 pub struct {{ endpoint.operation | pascalcase }}Response{
-	pub response: reqwest::Response, 
+	pub response: reqwest::Response,
 }
 
 impl {{ endpoint.operation | pascalcase }}Response{


### PR DESCRIPTION
Best way to import date_time in client/endpoints would be `{% if formats is containing("date-time") %}` but schema query parameters has not have object properties and codegen not appends formats. 

*I mark it as WIP, still looking for a better solution and inviting to discussion :)*
