### PR TITLE
feat: set model as response for not default content-type if response model exists

### DIFF
--- a/rust/_common/macros.j2
+++ b/rust/_common/macros.j2
@@ -128,18 +128,27 @@
 
 {% macro endpoint_return(success, endpoint, headers, options) -%}{% filter nospaces %}Result<
     {% if success == "no-models" or success.contentType is not starting_with("application/json") %}
-    {{ self::endpoint_default_response(endpoint = endpoint, options = options) }}
+        {% if success.model and success.model.type == "object" and success.model.model and success.model.model.name %}
+            {{ self::endpoint_model_response(success = success, headers = headers) }}
+        {% elif success.model and success.model.type == "wrapper" and success.model.model and success.model.model.type %}
+            {{ self::endpoint_model_response(success = success, headers = headers) }}
+        {% else %}
+            {{ self::endpoint_default_response(endpoint = endpoint, options = options) }}
+        {% endif %}
     {% elif success.model %}
-    {% if headers | length > 0 %}({% endif %}
-    {{ self::type(property = success.model, ns = "model") }}
-    {% if headers | length > 0 %}, reqwest::header::HeaderMap
-    ){% endif %}
+        {{ self::endpoint_model_response(success = success, headers = headers) }}
     {% else %}
     reqwest::Response
     {% endif %},
     {{ self::endpoint_error(endpoint = endpoint, options = options) }}
 >{% endfilter %}{%- endmacro skipped_headers %}
 
+{% macro endpoint_model_response(success, headers) -%}
+    {% if headers | length > 0 %}({% endif %}
+    {{ self::type(property = success.model, ns = "model") }}
+    {% if headers | length > 0 %}, reqwest::header::HeaderMap
+    ){% endif %}
+{%- endmacro endpoint_model_response %}
 {% macro endpoint_default_response(endpoint, options) -%}endpoint::{{ endpoint.operation | pascalcase }}Response{%- endmacro endpoint_default_response %}
 
 {% macro endpoint_error(endpoint, options) -%}{% filter nospaces %}

--- a/rust/client/mod.j2
+++ b/rust/client/mod.j2
@@ -181,7 +181,15 @@ impl {{ options.name }} {
                 .map_err(|e| {{ m::endpoint_map_error(reqwest = "e", endpoint = endpoint, options = options) }})
                 {% if success_headers | length > 0 %}.map(|d| (d, headers)){% endif %}
             {% else %}
-            return Ok({{ m::endpoint_default_response(endpoint = endpoint, options = options) }}::from_response(response))
+                {% if not success.model or not success.model.model or not success.model.model.name or not success.model.model.type %}
+                    return Ok({{ m::endpoint_default_response(endpoint = endpoint, options = options) }}::from_response(response))
+                {% else %}
+                    return response
+                        .json::<{{ m::type(property = success.model, ns = "model") }}>()
+                        .await
+                        .map_err(|e| {{ m::endpoint_map_error(reqwest = "e", endpoint = endpoint, options = options) }})
+                        {% if success_headers | length > 0 %}.map(|d| (d, headers)){% endif %}
+                {% endif %}
             {% endif %}
         }
 


### PR DESCRIPTION
there is a problem if one response have few types
for example changing listDevices200:
```
listDevices200:
  description: Operation succeeded.
  headers:
    traceparent:
      schema:
        $ref: ../../types.yaml#/TraceParent
    tracestate:
      schema:
        $ref: ../../types.yaml#/TraceState
  content:
    application/json:
      schema:
        title: ListDevicesResponse
        allOf:
          - $ref: ../../types.yaml#/MultipleResources
          - properties:
              data:
                type: array
                items:
                  $ref: schemas.yaml#/Device
    application/vnd.device-id+json:
      schema:
        title: ListDevicesIdsResponse
        allOf:
          - $ref: ../../types.yaml#/MultipleResources
          - properties:
              data:
                type: array
                items:
                  type: string
```