### PR TITLE
feat(rabbitmq): requeue option on handler

### DIFF
--- a/rust/rabbitmq/actix.j2
+++ b/rust/rabbitmq/actix.j2
@@ -468,6 +468,8 @@ pub mod consumer {
     pub enum Confirmation {
         Ack,
         Nack,
+        ReQueue,
+        Reject,
     }
 
     impl<O, E> Into<Confirmation> for Result<O, E> where O: Into<Confirmation>, E: Into<Confirmation> {
@@ -636,6 +638,19 @@ pub mod consumer {
                             Confirmation::Nack => {
                                 delivery
                                     .nack(lapin::options::BasicNackOptions::default())
+                                    .await
+                            }
+                            Confirmation::ReQueue => {
+                                let mut nackOptions = lapin::options::BasicNackOptions::default();
+                                nackOptions.requeue = true;
+
+                                delivery
+                                    .nack(nackOptions)
+                                    .await
+                            }
+                            Confirmation::Reject => {
+                                delivery
+                                    .reject(lapin::options::BasicRejectOptions::default())
                                     .await
                             }
                         } {


### PR DESCRIPTION
Include option to requeue and reject message.
to do that error needs to resolve as Confirmation::ReQueue or Confirmation::Reject