### PR TITLE
feat: switch from validator to garde

### DIFF
--- a/rust/_common/macros.j2
+++ b/rust/_common/macros.j2
@@ -74,6 +74,32 @@
     {% endif %}
 {% endfilter %}{% endmacro get_validation %}
 
+{% macro model_validation(model, options, regex_path="") %}{% filter nospaces %}
+    {%- if not options.skipValidate %}
+        {%- if model.validation and model.type != 'enum' %}
+            {%- if self::get_validation(validation = model.validation) | length %}
+                #[garde({{ self::get_validation(validation = model.validation, regex_path = regex_path) }})]
+            {%- else %}
+                #[garde(skip)]
+            {%- endif %}
+        {%- elif self::need_nested_validation(property=model) %}
+            #[garde(dive)]
+        {%- else %}
+            #[garde(skip)]
+        {%- endif %}
+    {%- endif %}
+{% endfilter %}{% endmacro model_validation %}
+
+{% macro enum_validation(option, options, regex_path="") %}{% filter nospaces %}
+    {%- if not options.skipValidate %}
+        {%- if option.x._discriminator.value.model %}
+            #[garde(dive)]
+        {%- else %}
+            #[garde(skip)]
+        {%- endif %}
+    {%- endif %}
+{% endfilter %}{% endmacro model_validation %}
+
 {% macro type(property, ns="") %}{% filter nospaces %}
 {% if property.nullable %}Option<{% endif %}
 

--- a/rust/_common/macros.j2
+++ b/rust/_common/macros.j2
@@ -62,8 +62,9 @@
     {% if validation.format and validation.format in ["decimal", "uuid"] %}{% else %}
     {% if validation.minLength %}length(min = {{ validation.minLength }}{% if validation.maxLength %}, max = {{ validation.maxLength }}{% endif %}), {% endif %}
     {% if validation.maxLength and not validation.minLength %}length(max = {{ validation.maxLength }}), {% endif %}
-    {% if validation.minItems %}length(min = {{ validation.minItems }}), {% endif %}
-    {% if validation.pattern %}regex(path = *{{ regex_path }}{{ validation.pattern.name | snakecase | upper }}), {% endif %}
+    {% if validation.minItems %}length(min = {{ validation.minItems }}{% if validation.maxItems %}, max = {{ validation.maxItems }}{% endif %}), {% endif %}
+    {% if validation.maxItems and not validation.minItems %}length(max = {{ validation.maxItems }}), {% endif %}
+    {% if validation.pattern %}pattern({{ regex_path }}{{ validation.pattern.name | snakecase | upper }}), {% endif %}
     {% if validation.minimum is defined or validation.maximum is defined %}
     range(
         {% if validation.minimum is defined %}min = {{ validation.minimum }}{% if validation.maximum is defined %}, {% endif %}{% endif %}

--- a/rust/_common/macros.j2
+++ b/rust/_common/macros.j2
@@ -58,27 +58,41 @@
 {{ name | pascalcase | when_numeric(prefix=base) }}
 {% endfilter %}{% endmacro enum_variant %}
 
-{% macro get_validation(validation, regex_path="") %}{% filter nospaces %}
-    {% if validation.format and validation.format in ["decimal", "uuid"] %}{% else %}
-    {% if validation.minLength %}length(min = {{ validation.minLength }}{% if validation.maxLength %}, max = {{ validation.maxLength }}{% endif %}), {% endif %}
-    {% if validation.maxLength and not validation.minLength %}length(max = {{ validation.maxLength }}), {% endif %}
-    {% if validation.minItems %}length(min = {{ validation.minItems }}{% if validation.maxItems %}, max = {{ validation.maxItems }}{% endif %}), {% endif %}
-    {% if validation.maxItems and not validation.minItems %}length(max = {{ validation.maxItems }}), {% endif %}
-    {% if validation.pattern %}pattern({{ regex_path }}{{ validation.pattern.name | snakecase | upper }}), {% endif %}
-    {% if validation.minimum is defined or validation.maximum is defined %}
-    range(
-        {% if validation.minimum is defined %}min = {{ validation.minimum }}{% if validation.maximum is defined %}, {% endif %}{% endif %}
-        {% if validation.maximum is defined %}max = {{ validation.maximum }}{% endif %}
-    )
-    {% endif %}
+{% macro get_validation(validation, regex_path="", form=false) %}{% filter nospaces %}
+    {% if validation.format and validation.format in ["decimal", "uuid"] %}
+    {% else %}
+        {% if validation.minLength %}length(min = {{ validation.minLength }}{% if validation.maxLength %}, max = {{ validation.maxLength }}{% endif %}), {% endif %}
+        {% if validation.maxLength and not validation.minLength %}length(max = {{ validation.maxLength }}), {% endif %}
+        {% if validation.minItems %}length(min = {{ validation.minItems }}{% if validation.maxItems %}, max = {{ validation.maxItems }}{% endif %}), {% endif %}
+        {% if validation.maxItems and not validation.minItems %}length(max = {{ validation.maxItems }}), {% endif %}
+        {% if form %}inner({% endif %}
+        {% if validation.pattern %}pattern({{ regex_path }}{{ validation.pattern.name | snakecase | upper }}), {% endif %}
+        {% if validation.minimum is defined or validation.maximum is defined %}
+        range(
+            {% if validation.minimum is defined %}min = {{ validation.minimum }}{% if validation.maximum is defined %}, {% endif %}{% endif %}
+            {% if validation.maximum is defined %}max = {{ validation.maximum }}{% endif %}
+        )
+        {% endif %}
+        {% if form %}){% endif %}
     {% endif %}
 {% endfilter %}{% endmacro get_validation %}
 
-{% macro model_validation(model, options, regex_path="") %}{% filter nospaces %}
+{% macro model_validation(model, options, regex_path="", style="") %}{% filter nospaces %}
     {%- if not options.skipValidate %}
         {%- if model.validation and model.type != 'enum' %}
-            {%- if self::get_validation(validation = model.validation) | length %}
-                #[garde({{ self::get_validation(validation = model.validation, regex_path = regex_path) }})]
+            {%- if self::get_validation(validation = model.validation, form = style == "form") | length %}
+                #[garde(
+                    {{ self::get_validation(validation = model.validation, regex_path = regex_path, form = style == "form") }}
+                    {%- if model.type == "array" and model.model.validation and model.model.type != "enum" %}
+                        inner({{ self::get_validation(validation = model.model.validation, regex_path = regex_path) }})
+                    {% endif %}
+                )]
+            {%- else %}
+                #[garde(skip)]
+            {%- endif %}
+        {%- elif model.type == 'array' and model.model.validation and model.model.type != "enum" %}
+            {%- if self::get_validation(validation = model.model.validation, form = style == "form") | length %}
+                #[garde(inner({{ self::get_validation(validation = model.model.validation, regex_path = regex_path, form = style == "form") }}))]
             {%- else %}
                 #[garde(skip)]
             {%- endif %}

--- a/rust/_common/models.j2
+++ b/rust/_common/models.j2
@@ -30,19 +30,7 @@ pub static {{ regexp.name | snakecase | upper }}: Lazy<Regex> = Lazy::new(|| { R
 pub struct {{ m::model_name(name = model.object.name) }} {
     {%- set filtered_properties = model.object.properties | filter_not(attribute="type", value="const") -%}
     {% for property in filtered_properties -%}
-    {%- if not options.skipValidate %}
-    {%- if property.validation and property.type != 'enum' %}
-    {%- if m::get_validation(validation = property.validation) | length %}
-    #[garde({{ m::get_validation(validation = property.validation) }})]
-    {%- else %}
-    #[garde(skip)]
-    {%- endif %}
-    {%- elif m::need_nested_validation(property=property) %}
-    #[garde(dive)]
-    {%- else %}
-    #[garde(skip)]
-    {%- endif %}
-    {%- endif %}
+    {{- m::model_validation(model = property, options = options) }}
     #[serde(rename = "{{ property.name }}"{% if not property.required and property.nullable %}, default, deserialize_with = "optional_nullable"{% elif not property.required %}, skip_serializing_if = "Option::is_none"{% endif %})]
     pub {{ m::property_name(name = property.name) }}: {% if not property.required %}Option<{% endif %}{{ m::type(property = property) }}{% if not property.required %}>{% endif %},
     {%- endfor %}
@@ -133,18 +121,16 @@ impl std::str::FromStr for {{ m::model_name(name = model.enum.name) }}Variant {
 
 {%- elif model.wrapper %}
 {% if model.wrapper.strategy and model.wrapper.strategy == "externally" %}
-#[derive(Debug, Clone, Validate, Deserialize, Serialize)]
+#[derive(Debug, Clone, {% if not options.skipValidate %}Validate, {% endif %}Deserialize, Serialize)]
 pub enum {{ m::model_name(name = model.wrapper.name) }} {
     {% for option in model.wrapper.models -%}
     #[serde(rename = "{{ option.x._discriminator.property }}")]
     {{ option.x._discriminator.property | pascalcase }}(
         {%- if option.x._discriminator.value.model -%}
-        {%- if not options.skipValidate %}{%- if m::need_nested_validation(property=option) %}
-            #[garde(dive)]
-        {%- endif %}{%- endif %}
+        {{- m::enum_validation(option = option, options = options) }}
         {{ option.x._discriminator.value.model }}
         {%- elif option.x._discriminator.value.simple -%}
-        {%- if not options.skipValidate %}#[garde(skip)]{%- endif %}
+        {{- m::enum_validation(option = option, options = options) }}
         {{ m::type(property = option.x._discriminator.value.simple) }}
         {%- endif -%}
     ),
@@ -152,22 +138,22 @@ pub enum {{ m::model_name(name = model.wrapper.name) }} {
 }
 
 {% elif model.wrapper.strategy.internally %}
-#[derive(Debug, Clone, Validate, Deserialize, Serialize)]
+#[derive(Debug, Clone, {% if not options.skipValidate %}Validate, {% endif %}Deserialize, Serialize)]
 #[serde(tag = "{{ model.wrapper.strategy.internally }}")]
 pub enum {{ m::model_name(name = model.wrapper.name) }} {
     {% for option in model.wrapper.models -%}
     #[serde(rename = "{{ option.x._discriminator.value.model }}")]
-    {{ option.x._discriminator.value.model | pascalcase }}{% if option.x._discriminator.properties | default(value = 0) > 0 %}({%- if not options.skipValidate %}{%- if m::need_nested_validation(property=option) %}#[garde(dive)] {% else %}#[garde(skip)] {% endif -%}{% endif -%}{{ m::type(property = option) }}){% endif %},
+    {{ option.x._discriminator.value.model | pascalcase }}{% if option.x._discriminator.properties | default(value = 0) > 0 %}({{- m::enum_validation(option = option, options = options) }}{{ m::type(property = option) }}){% endif %},
     {% endfor %}
 }
 
 {% else -%}
-#[derive(Debug, Clone, Validate, Serialize, Deserialize)]
+#[derive(Debug, Clone, {% if not options.skipValidate %}Validate, {% endif %}Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum {{ m::model_name(name = model.wrapper.name) }} {
     {% for option in model.wrapper.models -%}
-    {{ m::type(property = option) | pascalcase }}({%- if not options.skipValidate %}{%- if m::need_nested_validation(property=option) %}
-        #[garde(dive)]{% else %}#[garde(skip)]{%- endif %}{%- endif %}
+    {{ m::type(property = option) | pascalcase }}(
+        {{- m::enum_validation(option = option, options = options) }}
         {{ m::type(property = option) }}
     ),
     {% endfor %}

--- a/rust/_common/models.j2
+++ b/rust/_common/models.j2
@@ -4,7 +4,7 @@
 {{ m::do_not_modify() }}
 use serde::{Serialize, Deserialize, Deserializer};
 use std::collections::BTreeMap;
-{% if not options.skipValidate %}use validator::Validate;
+{% if not options.skipValidate %}use garde::Validate;
 use regex::Regex;
 use once_cell::sync::Lazy;{% endif %}
 {% block use %}{% endblock use %}
@@ -30,12 +30,18 @@ pub static {{ regexp.name | snakecase | upper }}: Lazy<Regex> = Lazy::new(|| { R
 pub struct {{ m::model_name(name = model.object.name) }} {
     {%- set filtered_properties = model.object.properties | filter_not(attribute="type", value="const") -%}
     {% for property in filtered_properties -%}
+    {%- if not options.skipValidate %}
     {%- if property.validation and property.type != 'enum' %}
     {%- if m::get_validation(validation = property.validation) | length %}
-    {% if not options.skipValidate %}#[validate({{ m::get_validation(validation = property.validation) }})]{% endif %}
+    #[garde({{ m::get_validation(validation = property.validation) }})]
+    {%- else %}
+    #[garde(skip)]
     {%- endif %}
-    {%- elif m::need_nested_validation(property=property)%}
-    {% if not options.skipValidate %}#[validate]{% endif %}
+    {%- elif m::need_nested_validation(property=property) %}
+    #[garde(dive)]
+    {%- else %}
+    #[garde(skip)]
+    {%- endif %}
     {%- endif %}
     #[serde(rename = "{{ property.name }}"{% if not property.required and property.nullable %}, default, deserialize_with = "optional_nullable"{% elif not property.required %}, skip_serializing_if = "Option::is_none"{% endif %})]
     pub {{ m::property_name(name = property.name) }}: {% if not property.required %}Option<{% endif %}{{ m::type(property = property) }}{% if not property.required %}>{% endif %},
@@ -87,15 +93,15 @@ pub enum {{ m::model_name(name = model.enum.name) }}Variant {
 impl std::string::ToString for {{ m::model_name(name = model.enum.name) }}Variant {
     fn to_string(&self) -> String {
         match self {
-            {% for option in model.enum.options -%}
-            Self::{% if option == option | when_numeric(prefix="n") | pascalcase -%}
+            {%- for option in model.enum.options %}
+            Self::{%- if option == option | when_numeric(prefix="n") | pascalcase -%}
             {{ option }}
-            {%- elif model.enum.type == "number" %}
+            {%- elif model.enum.type == "number" -%}
             {{ m::enum_variant(name = option, base = m::model_name(name = model.enum.name) ) }}
-            {%- elif option is matching("^[\d]+") %}
-            {%set a = 'Code' ~ option %}
+            {%- elif option is matching("^[\d]+") -%}
+            {% set a = 'Code' ~ option %}
             {{ m::enum_variant(name = a, base = m::model_name(name = a)) }}
-            {%- else %}
+            {%- else -%}
             {{ m::enum_variant(name = option, base = m::model_name(name = model.enum.name)) }}
             {%- endif %} => "{{ option }}",
             {%- endfor %}
@@ -108,15 +114,15 @@ impl std::str::FromStr for {{ m::model_name(name = model.enum.name) }}Variant {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            {% for option in model.enum.options -%}
-            "{{ option }}" => Ok(Self::{% if option == option | when_numeric(prefix="n") | pascalcase -%}
+            {%- for option in model.enum.options %}
+            "{{ option }}" => Ok(Self::{%- if option == option | when_numeric(prefix="n") | pascalcase -%}
             {{ option }}
-            {%- elif model.enum.type == "number" %}
+            {%- elif model.enum.type == "number" -%}
             {{ m::enum_variant(name = option, base = m::model_name(name = model.enum.name) ) }}
-            {%- elif option is matching("^[\d]+") %}
-            {%set a = 'Code' ~ option %}
+            {%- elif option is matching("^[\d]+") -%}
+            {% set a = 'Code' ~ option %}
             {{ m::enum_variant(name = a, base = m::model_name(name = a)) }}
-            {%- else %}
+            {%- else -%}
             {{ m::enum_variant(name = option, base = m::model_name(name = model.enum.name)) }}
             {%- endif %}),
             {%- endfor %}
@@ -127,14 +133,18 @@ impl std::str::FromStr for {{ m::model_name(name = model.enum.name) }}Variant {
 
 {%- elif model.wrapper %}
 {% if model.wrapper.strategy and model.wrapper.strategy == "externally" %}
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Validate, Deserialize, Serialize)]
 pub enum {{ m::model_name(name = model.wrapper.name) }} {
     {% for option in model.wrapper.models -%}
     #[serde(rename = "{{ option.x._discriminator.property }}")]
     {{ option.x._discriminator.property | pascalcase }}(
         {%- if option.x._discriminator.value.model -%}
+        {%- if not options.skipValidate %}{%- if m::need_nested_validation(property=option) %}
+            #[garde(dive)]
+        {%- endif %}{%- endif %}
         {{ option.x._discriminator.value.model }}
         {%- elif option.x._discriminator.value.simple -%}
+        {%- if not options.skipValidate %}#[garde(skip)]{%- endif %}
         {{ m::type(property = option.x._discriminator.value.simple) }}
         {%- endif -%}
     ),
@@ -142,53 +152,28 @@ pub enum {{ m::model_name(name = model.wrapper.name) }} {
 }
 
 {% elif model.wrapper.strategy.internally %}
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Validate, Deserialize, Serialize)]
 #[serde(tag = "{{ model.wrapper.strategy.internally }}")]
 pub enum {{ m::model_name(name = model.wrapper.name) }} {
     {% for option in model.wrapper.models -%}
     #[serde(rename = "{{ option.x._discriminator.value.model }}")]
-    {{ option.x._discriminator.value.model | pascalcase }}{% if option.x._discriminator.properties | default(value = 0) > 0 %}({{ m::type(property = option) }}){% endif %},
+    {{ option.x._discriminator.value.model | pascalcase }}{% if option.x._discriminator.properties | default(value = 0) > 0 %}({%- if not options.skipValidate %}{%- if m::need_nested_validation(property=option) %}#[garde(dive)] {% else %}#[garde(skip)] {% endif -%}{% endif -%}{{ m::type(property = option) }}){% endif %},
     {% endfor %}
 }
 
 {% else -%}
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Validate, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum {{ m::model_name(name = model.wrapper.name) }} {
     {% for option in model.wrapper.models -%}
-    {{ m::type(property = option) | pascalcase }}({{ m::type(property = option) }}),
+    {{ m::type(property = option) | pascalcase }}({%- if not options.skipValidate %}{%- if m::need_nested_validation(property=option) %}
+        #[garde(dive)]{% else %}#[garde(skip)]{%- endif %}{%- endif %}
+        {{ m::type(property = option) }}
+    ),
     {% endfor %}
 }
 
 {% endif -%}
-
-{% if not options.skipValidate %}
-{% if model.wrapper.strategy and model.wrapper.strategy == "externally" or model.wrapper.strategy.internally %}
-impl Validate for {{ m::model_name(name = model.wrapper.name) }} {
-    fn validate(&self) -> Result<(), validator::ValidationErrors> {
-        match self {
-            {% for option in model.wrapper.models -%}
-            Self::{% if model.wrapper.strategy.internally -%}
-            {{ option.x._discriminator.value.model | pascalcase }}
-            {%- else -%}
-            {{ option.x._discriminator.property | pascalcase }}
-            {%- endif %}{% if option.x._discriminator.properties | default(value = 0) > 0 %}(d)  => {% if option.x._discriminator.value.model %}d.validate(),{% else %}Ok(()),{% endif %}{%else %} => Ok(()),{% endif %}
-            {% endfor %}
-        }
-    }
-}
-{% else %}
-impl Validate for {{ m::model_name(name = model.wrapper.name) }} {
-    fn validate(&self) -> Result<(), validator::ValidationErrors> {
-        match self {
-            {% for option in model.wrapper.models -%}
-            Self::{{ m::type(property = option) | pascalcase }}(d) => {% if option.model %}d.validate(),{% else %}Ok(()),{% endif %}
-            {% endfor %}
-        }
-    }
-}
-{% endif %}
-{% endif %}
 
 {%- elif model.primitive %}
 pub type {{ m::model_name(name = model.primitive.name) }} = {{ m::type(property = model.primitive) }};

--- a/rust/server-actix/endpoints.j2
+++ b/rust/server-actix/endpoints.j2
@@ -34,11 +34,12 @@ pub struct {{ endpoint.operation | pascalcase }}Path{
 #[derive({% if not options.skipValidate %}Validate, {% endif %}Deserialize{% if object_all_optional %},Default{% endif %})]
 pub struct {{ endpoint.operation | pascalcase }}Query{
 	{% for param in endpoint.parameters.query %}
-    {{- m::model_validation(model = param.model, options = options, regex_path="super::model::") }}
 	{% if param.style == 'form' and param.explode == false %}
+    {{ m::model_validation(model = param.model, options = options, regex_path="super::model::", style="form") }}
 	#[serde(rename = "{{ param.name }}", deserialize_with = "deserialized_id_list"{% if property.required %}, skip_serializing_if = "Option::is_none"{% endif %})]
 	pub {{ m::property_name(name = param.name) }}: {% if not param.required %}Option<{% endif %}Vec<{{ m::type(property = param.model, ns = "super::model") }}{% if not param.required %}>{% endif %}>,
 	{% else %}
+    {{ m::model_validation(model = param.model, options = options, regex_path="super::model::") }}
 	#[serde(rename = "{{ param.name }}"{% if property.required %}, skip_serializing_if = "Option::is_none"{% endif %})]
 	pub {{ m::property_name(name = param.name) }}: {% if not param.required %}Option<{% endif %}{{ m::type(property = param.model, ns = "super::model") }}{% if not param.required %}>{% endif %},
 	{% endif %}

--- a/rust/server-actix/endpoints.j2
+++ b/rust/server-actix/endpoints.j2
@@ -3,6 +3,7 @@
 {%- import "extra.j2" as e -%}
 {{ m::do_not_modify() }}
 use actix_web::{HttpResponse, http::{StatusCode, header::HeaderName}};
+use garde::Validate;
 use serde::{de::{self, IntoDeserializer}, Deserialize};
 use std::fmt;
 
@@ -15,9 +16,20 @@ use std::fmt;
 // {{ endpoint.method }} {{ endpoint.path }}
 //
 {% if endpoint.parameters.path | length > 0 -%}
-#[derive(Deserialize)]
+#[derive(Validate, Deserialize)]
 pub struct {{ endpoint.operation | pascalcase }}Path{
 	{% for param in endpoint.parameters.path %}
+    {%- if param.model.validation and param.model.type != 'enum' %}
+    {%- if m::get_validation(validation = param.model.validation) | length %}
+    #[garde({{ m::get_validation(validation = param.model.validation, regex_path="super::model::") }})]
+    {%- else %}
+    #[garde(skip)]
+    {%- endif %}
+    {%- elif m::need_nested_validation(property=param.model) %}
+    #[garde(dive)]
+    {%- else %}
+    #[garde(skip)]
+    {%- endif %}
 	#[serde(rename = "{{ param.name }}"{% if property.required %}, skip_serializing_if = "Option::is_none"{% endif %})]
 	pub {{ m::property_name(name = param.name) }}: {{ m::type(property = param.model) }},
 	{% endfor %}
@@ -29,9 +41,20 @@ pub struct {{ endpoint.operation | pascalcase }}Path{
 {% set object_query_params = endpoint.parameters.query | filter(attribute="model.type", value="object") | length == 0 %}
 {% set object_all_optional = endpoint.parameters.query | filter(attribute="required", value=true) | length == 0 %}
 
-#[derive(Deserialize{% if object_all_optional %},Default{% endif %})]
+#[derive(Validate, Deserialize{% if object_all_optional %},Default{% endif %})]
 pub struct {{ endpoint.operation | pascalcase }}Query{
 	{% for param in endpoint.parameters.query %}
+    {%- if param.model.validation and param.model.type != 'enum' %}
+    {%- if m::get_validation(validation = param.model.validation) | length %}
+    #[garde({{ m::get_validation(validation = param.model.validation) }})]
+    {%- else %}
+    #[garde(skip)]
+    {%- endif %}
+    {%- elif m::need_nested_validation(property=param.model) %}
+    #[garde(dive)]
+    {%- else %}
+    #[garde(skip)]
+    {%- endif %}
 	{% if param.style == 'form' and param.explode == false %}
 	#[serde(rename = "{{ param.name }}", deserialize_with = "deserialized_id_list"{% if property.required %}, skip_serializing_if = "Option::is_none"{% endif %})]
 	pub {{ m::property_name(name = param.name) }}: {% if not param.required %}Option<{% endif %}Vec<{{ m::type(property = param.model, ns = "super::model") }}{% if not param.required %}>{% endif %}>,
@@ -47,9 +70,20 @@ pub struct {{ endpoint.operation | pascalcase }}Query{
 {% set skipped_headers = e::skipped_headers(endpoint=endpoint, options=options) | split(pat=" ") %}
 {% set filtered_headers = endpoint.parameters.header | filter_not_inarray(attribute="name", values=skipped_headers) %}
 {%- if filtered_headers | length > 0 %}
-#[derive(Deserialize)]
+#[derive(Validate, Deserialize)]
 pub struct {{ endpoint.operation | pascalcase }}RequestHeaders{
 	{% for param in filtered_headers %}
+    {%- if param.model.validation and param.model.type != 'enum' %}
+    {%- if m::get_validation(validation = param.model.validation) | length %}
+    #[garde({{ m::get_validation(validation = param.model.validation) }})]
+    {%- else %}
+    #[garde(skip)]
+    {%- endif %}
+    {%- elif m::need_nested_validation(property=param.model) %}
+    #[garde(dive)]
+    {%- else %}
+    #[garde(skip)]
+    {%- endif %}
 	#[serde(rename = "{{ param.name }}"{% if property.required %}, skip_serializing_if = "Option::is_none"{% endif %})]
 	pub {{ m::property_name(name = param.name) }}: {% if not param.required %}Option<{% endif %}{{ m::type(property = param.model, ns = "super::model") }}{% if not param.required %}>{% endif %},
 	{% endfor %}
@@ -153,7 +187,7 @@ impl From<{% if filtered_response_headers | length == 0 %}{{ m::type(property = 
             builder.append_header((HeaderName::from_static("{{ param.name | lower }}"), header));
         }
         {% endfor %}
-    
+
         builder.json({% if filtered_response_headers | length == 0 %}d{% else %}d.body{% endif %})
     }
 }

--- a/rust/server-actix/endpoints.j2
+++ b/rust/server-actix/endpoints.j2
@@ -16,20 +16,10 @@ use std::fmt;
 // {{ endpoint.method }} {{ endpoint.path }}
 //
 {% if endpoint.parameters.path | length > 0 -%}
-#[derive(Validate, Deserialize)]
+#[derive({% if not options.skipValidate %}Validate, {% endif %}Deserialize)]
 pub struct {{ endpoint.operation | pascalcase }}Path{
 	{% for param in endpoint.parameters.path %}
-    {%- if param.model.validation and param.model.type != 'enum' %}
-    {%- if m::get_validation(validation = param.model.validation) | length %}
-    #[garde({{ m::get_validation(validation = param.model.validation, regex_path="super::model::") }})]
-    {%- else %}
-    #[garde(skip)]
-    {%- endif %}
-    {%- elif m::need_nested_validation(property=param.model) %}
-    #[garde(dive)]
-    {%- else %}
-    #[garde(skip)]
-    {%- endif %}
+    {{- m::model_validation(model = param.model, options = options, regex_path="super::model::") }}
 	#[serde(rename = "{{ param.name }}"{% if property.required %}, skip_serializing_if = "Option::is_none"{% endif %})]
 	pub {{ m::property_name(name = param.name) }}: {{ m::type(property = param.model) }},
 	{% endfor %}
@@ -41,20 +31,10 @@ pub struct {{ endpoint.operation | pascalcase }}Path{
 {% set object_query_params = endpoint.parameters.query | filter(attribute="model.type", value="object") | length == 0 %}
 {% set object_all_optional = endpoint.parameters.query | filter(attribute="required", value=true) | length == 0 %}
 
-#[derive(Validate, Deserialize{% if object_all_optional %},Default{% endif %})]
+#[derive({% if not options.skipValidate %}Validate, {% endif %}Deserialize{% if object_all_optional %},Default{% endif %})]
 pub struct {{ endpoint.operation | pascalcase }}Query{
 	{% for param in endpoint.parameters.query %}
-    {%- if param.model.validation and param.model.type != 'enum' %}
-    {%- if m::get_validation(validation = param.model.validation) | length %}
-    #[garde({{ m::get_validation(validation = param.model.validation) }})]
-    {%- else %}
-    #[garde(skip)]
-    {%- endif %}
-    {%- elif m::need_nested_validation(property=param.model) %}
-    #[garde(dive)]
-    {%- else %}
-    #[garde(skip)]
-    {%- endif %}
+    {{- m::model_validation(model = param.model, options = options, regex_path="super::model::") }}
 	{% if param.style == 'form' and param.explode == false %}
 	#[serde(rename = "{{ param.name }}", deserialize_with = "deserialized_id_list"{% if property.required %}, skip_serializing_if = "Option::is_none"{% endif %})]
 	pub {{ m::property_name(name = param.name) }}: {% if not param.required %}Option<{% endif %}Vec<{{ m::type(property = param.model, ns = "super::model") }}{% if not param.required %}>{% endif %}>,
@@ -70,20 +50,10 @@ pub struct {{ endpoint.operation | pascalcase }}Query{
 {% set skipped_headers = e::skipped_headers(endpoint=endpoint, options=options) | split(pat=" ") %}
 {% set filtered_headers = endpoint.parameters.header | filter_not_inarray(attribute="name", values=skipped_headers) %}
 {%- if filtered_headers | length > 0 %}
-#[derive(Validate, Deserialize)]
+#[derive({% if not options.skipValidate %}Validate, {% endif %}Deserialize)]
 pub struct {{ endpoint.operation | pascalcase }}RequestHeaders{
 	{% for param in filtered_headers %}
-    {%- if param.model.validation and param.model.type != 'enum' %}
-    {%- if m::get_validation(validation = param.model.validation) | length %}
-    #[garde({{ m::get_validation(validation = param.model.validation) }})]
-    {%- else %}
-    #[garde(skip)]
-    {%- endif %}
-    {%- elif m::need_nested_validation(property=param.model) %}
-    #[garde(dive)]
-    {%- else %}
-    #[garde(skip)]
-    {%- endif %}
+    {{- m::model_validation(model = param.model, options = options, regex_path="super::model::") }}
 	#[serde(rename = "{{ param.name }}"{% if property.required %}, skip_serializing_if = "Option::is_none"{% endif %})]
 	pub {{ m::property_name(name = param.name) }}: {% if not param.required %}Option<{% endif %}{{ m::type(property = param.model, ns = "super::model") }}{% if not param.required %}>{% endif %},
 	{% endfor %}

--- a/rust/server-axum/endpoints.j2
+++ b/rust/server-axum/endpoints.j2
@@ -32,20 +32,10 @@ impl IntoResponse for FailedToDeserializeQuery {
 {% if endpoint.parameters.path | length > 0 -%}
 /// {{ endpoint.method | upper }} {{ endpoint.path }}
 /// path parameters
-#[derive(Validate, Deserialize)]
+#[derive({% if not options.skipValidate %}Validate, {% endif %}Deserialize)]
 pub struct {{ endpoint.operation | pascalcase }}Path{
 	{%- for param in endpoint.parameters.path %}
-    {%- if param.model.validation and param.model.type != 'enum' %}
-    {%- if m::get_validation(validation = param.model.validation) | length %}
-    #[garde({{ m::get_validation(validation = param.model.validation, regex_path="super::model::") }})]
-    {%- else %}
-    #[garde(skip)]
-    {%- endif %}
-    {%- elif m::need_nested_validation(property=param.model) %}
-    #[garde(dive)]
-    {%- else %}
-    #[garde(skip)]
-    {%- endif %}
+    {{- m::model_validation(model = param.model, options = options, regex_path="super::model::") }}
 	#[serde(rename = "{{ param.name }}"{% if property.required %}, skip_serializing_if = "Option::is_none"{% endif %})]
 	pub {{ m::property_name(name = param.name) }}: {{ m::type(property = param.model) }},
 	{% endfor %}
@@ -58,20 +48,10 @@ pub struct {{ endpoint.operation | pascalcase }}Path{
 
 /// {{ endpoint.method | upper }} {{ endpoint.path }}
 /// query parameters
-#[derive(Validate, Deserialize{% if object_all_optional %},Default{% endif %})]
+#[derive({% if not options.skipValidate %}Validate, {% endif %}Deserialize{% if object_all_optional %},Default{% endif %})]
 pub struct {{ endpoint.operation | pascalcase }}Query{
 	{%- for param in endpoint.parameters.query %}
-    {%- if param.model.validation and param.model.type != 'enum' %}
-    {%- if m::get_validation(validation = param.model.validation) | length %}
-    #[garde({{ m::get_validation(validation = param.model.validation) }})]
-    {%- else %}
-    #[garde(skip)]
-    {%- endif %}
-    {%- elif m::need_nested_validation(property=param.model) %}
-    #[garde(dive)]
-    {%- else %}
-    #[garde(skip)]
-    {%- endif %}
+    {{- m::model_validation(model = param.model, options = options, regex_path="super::model::") }}
 	{%- if param.style == 'form' and param.explode == false %}
 	#[serde(rename = "{{ param.name }}", deserialize_with = "deserialized_id_list"{% if property.required %}, skip_serializing_if = "Option::is_none"{% endif %})]
 	pub {{ m::property_name(name = param.name) }}: {% if not param.required %}Option<{% endif %}Vec<{{ m::type(property = param.model, ns = "super::model") }}{% if not param.required %}>{% endif %}>,
@@ -89,20 +69,10 @@ pub struct {{ endpoint.operation | pascalcase }}Query{
 {%- if filtered_headers | length > 0 %}
 /// {{ endpoint.method | upper }} {{ endpoint.path }}
 /// request headers
-#[derive(Validate, Deserialize)]
+#[derive({% if not options.skipValidate %}Validate, {% endif %}Deserialize)]
 pub struct {{ endpoint.operation | pascalcase }}RequestHeaders{
 	{%- for param in filtered_headers %}
-    {%- if param.model.validation and param.model.type != 'enum' %}
-    {%- if m::get_validation(validation = param.model.validation) | length %}
-    #[garde({{ m::get_validation(validation = param.model.validation) }})]
-    {%- else %}
-    #[garde(skip)]
-    {%- endif %}
-    {%- elif m::need_nested_validation(property=param.model) %}
-    #[garde(dive)]
-    {%- else %}
-    #[garde(skip)]
-    {%- endif %}
+    {{- m::model_validation(model = param.model, options = options, regex_path="super::model::") }}
 	#[serde(rename = "{{ param.name }}"{% if property.required %}, skip_serializing_if = "Option::is_none"{% endif %})]
 	pub {{ m::property_name(name = param.name) }}: {% if not param.required %}Option<{% endif %}{{ m::type(property = param.model, ns = "super::model") }}{% if not param.required %}>{% endif %},
 	{% endfor %}

--- a/rust/server-axum/endpoints.j2
+++ b/rust/server-axum/endpoints.j2
@@ -51,11 +51,12 @@ pub struct {{ endpoint.operation | pascalcase }}Path{
 #[derive({% if not options.skipValidate %}Validate, {% endif %}Deserialize{% if object_all_optional %},Default{% endif %})]
 pub struct {{ endpoint.operation | pascalcase }}Query{
 	{%- for param in endpoint.parameters.query %}
-    {{- m::model_validation(model = param.model, options = options, regex_path="super::model::") }}
 	{%- if param.style == 'form' and param.explode == false %}
+    {{ m::model_validation(model = param.model, options = options, regex_path="super::model::", style="form") }}
 	#[serde(rename = "{{ param.name }}", deserialize_with = "deserialized_id_list"{% if property.required %}, skip_serializing_if = "Option::is_none"{% endif %})]
 	pub {{ m::property_name(name = param.name) }}: {% if not param.required %}Option<{% endif %}Vec<{{ m::type(property = param.model, ns = "super::model") }}{% if not param.required %}>{% endif %}>,
 	{%- else %}
+    {{ m::model_validation(model = param.model, options = options, regex_path="super::model::") }}
 	#[serde(rename = "{{ param.name }}"{% if property.required %}, skip_serializing_if = "Option::is_none"{% endif %})]
 	pub {{ m::property_name(name = param.name) }}: {% if not param.required %}Option<{% endif %}{{ m::type(property = param.model, ns = "super::model") }}{% if not param.required %}>{% endif %},
 	{%- endif %}

--- a/rust/server-axum/endpoints.j2
+++ b/rust/server-axum/endpoints.j2
@@ -4,6 +4,7 @@
 {{ m::do_not_modify() }}
 use async_trait::async_trait;
 use axum::{body::Body, http::{HeaderValue, Response, StatusCode}, response::IntoResponse, Json, http};
+use garde::Validate;
 use serde::{
     de::{self, IntoDeserializer},
     Deserialize,
@@ -12,7 +13,6 @@ use serde_qs::Error;
 use std::fmt;
 use axum::extract::FromRequestParts;
 use axum::http::request::Parts;
-use validator::Validate;
 
 {% set_global froms = [] %}
 {% set_global froms_with_headers = [] %}
@@ -34,11 +34,17 @@ impl IntoResponse for FailedToDeserializeQuery {
 /// path parameters
 #[derive(Validate, Deserialize)]
 pub struct {{ endpoint.operation | pascalcase }}Path{
-	{% for param in endpoint.parameters.path %}
-    {% if param.model.validation and param.model.type != 'enum' %}
-    {% if m::get_validation(validation = param.model.validation) | length %}
-    #[validate({{ m::get_validation(validation = param.model.validation, regex_path="super::model::") }})]
-    {% endif %}
+	{%- for param in endpoint.parameters.path %}
+    {%- if param.model.validation and param.model.type != 'enum' %}
+    {%- if m::get_validation(validation = param.model.validation) | length %}
+    #[garde({{ m::get_validation(validation = param.model.validation, regex_path="super::model::") }})]
+    {%- else %}
+    #[garde(skip)]
+    {%- endif %}
+    {%- elif m::need_nested_validation(property=param.model) %}
+    #[garde(dive)]
+    {%- else %}
+    #[garde(skip)]
     {%- endif %}
 	#[serde(rename = "{{ param.name }}"{% if property.required %}, skip_serializing_if = "Option::is_none"{% endif %})]
 	pub {{ m::property_name(name = param.name) }}: {{ m::type(property = param.model) }},
@@ -54,19 +60,25 @@ pub struct {{ endpoint.operation | pascalcase }}Path{
 /// query parameters
 #[derive(Validate, Deserialize{% if object_all_optional %},Default{% endif %})]
 pub struct {{ endpoint.operation | pascalcase }}Query{
-	{% for param in endpoint.parameters.query %}
-    {% if param.model.validation and param.model.type != 'enum' %}
-    {% if m::get_validation(validation = param.model.validation) | length %}
-    #[validate({{ m::get_validation(validation = param.model.validation) }})]
-    {% endif %}
+	{%- for param in endpoint.parameters.query %}
+    {%- if param.model.validation and param.model.type != 'enum' %}
+    {%- if m::get_validation(validation = param.model.validation) | length %}
+    #[garde({{ m::get_validation(validation = param.model.validation) }})]
+    {%- else %}
+    #[garde(skip)]
     {%- endif %}
-	{% if param.style == 'form' and param.explode == false %}
+    {%- elif m::need_nested_validation(property=param.model) %}
+    #[garde(dive)]
+    {%- else %}
+    #[garde(skip)]
+    {%- endif %}
+	{%- if param.style == 'form' and param.explode == false %}
 	#[serde(rename = "{{ param.name }}", deserialize_with = "deserialized_id_list"{% if property.required %}, skip_serializing_if = "Option::is_none"{% endif %})]
 	pub {{ m::property_name(name = param.name) }}: {% if not param.required %}Option<{% endif %}Vec<{{ m::type(property = param.model, ns = "super::model") }}{% if not param.required %}>{% endif %}>,
-	{% else %}
+	{%- else %}
 	#[serde(rename = "{{ param.name }}"{% if property.required %}, skip_serializing_if = "Option::is_none"{% endif %})]
 	pub {{ m::property_name(name = param.name) }}: {% if not param.required %}Option<{% endif %}{{ m::type(property = param.model, ns = "super::model") }}{% if not param.required %}>{% endif %},
-	{% endif %}
+	{%- endif %}
 	{% endfor %}
 }
 
@@ -79,7 +91,18 @@ pub struct {{ endpoint.operation | pascalcase }}Query{
 /// request headers
 #[derive(Validate, Deserialize)]
 pub struct {{ endpoint.operation | pascalcase }}RequestHeaders{
-	{% for param in filtered_headers %}
+	{%- for param in filtered_headers %}
+    {%- if param.model.validation and param.model.type != 'enum' %}
+    {%- if m::get_validation(validation = param.model.validation) | length %}
+    #[garde({{ m::get_validation(validation = param.model.validation) }})]
+    {%- else %}
+    #[garde(skip)]
+    {%- endif %}
+    {%- elif m::need_nested_validation(property=param.model) %}
+    #[garde(dive)]
+    {%- else %}
+    #[garde(skip)]
+    {%- endif %}
 	#[serde(rename = "{{ param.name }}"{% if property.required %}, skip_serializing_if = "Option::is_none"{% endif %})]
 	pub {{ m::property_name(name = param.name) }}: {% if not param.required %}Option<{% endif %}{{ m::type(property = param.model, ns = "super::model") }}{% if not param.required %}>{% endif %},
 	{% endfor %}

--- a/tests/rust-axum-relaxed/Cargo.lock
+++ b/tests/rust-axum-relaxed/Cargo.lock
@@ -114,7 +114,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
 ]
 
 [[package]]
@@ -125,7 +125,7 @@ checksum = "461abc97219de0eaaf81fe3ef974a540158f3d079c2ab200f891f1a2ef201e85"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
 ]
 
 [[package]]
@@ -244,7 +244,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
 ]
 
 [[package]]
@@ -293,6 +293,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
+name = "castaway"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a17ed5635fc8536268e5d4de1e22e81ac34419e5f052d4d51f4e01dcc263fcc"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +335,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "compact_str"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,41 +377,6 @@ name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
-
-[[package]]
-name = "darling"
-version = "0.20.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.53",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
-dependencies = [
- "darling_core",
- "quote",
- "syn 2.0.53",
-]
 
 [[package]]
 name = "either"
@@ -537,7 +524,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
 ]
 
 [[package]]
@@ -568,6 +555,31 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "garde"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fa8fb3ffe035745c6194540b2064b2fe275f32367fbb4eb026024b7921e2e5"
+dependencies = [
+ "compact_str",
+ "garde_derive",
+ "once_cell",
+ "regex",
+ "smallvec",
+]
+
+[[package]]
+name = "garde_derive"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf62650515830c41553b72bd49ec20fb120226f9277c7f2847f071cf998325b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
 ]
 
 [[package]]
@@ -838,12 +850,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1060,7 +1066,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
 ]
 
 [[package]]
@@ -1214,7 +1220,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
 ]
 
 [[package]]
@@ -1240,30 +1246,6 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -1294,7 +1276,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
 ]
 
 [[package]]
@@ -1473,6 +1455,7 @@ dependencies = [
  "env_logger",
  "futures",
  "futures-core",
+ "garde",
  "log",
  "once_cell",
  "opentelemetry",
@@ -1490,7 +1473,6 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
- "validator",
 ]
 
 [[package]]
@@ -1539,7 +1521,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
 ]
 
 [[package]]
@@ -1582,7 +1564,7 @@ checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
 ]
 
 [[package]]
@@ -1641,20 +1623,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.10.0"
+name = "static_assertions"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "unicode-ident",
-]
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
@@ -1723,7 +1695,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
 ]
 
 [[package]]
@@ -1788,7 +1760,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
 ]
 
 [[package]]
@@ -1905,7 +1877,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
 ]
 
 [[package]]
@@ -2023,36 +1995,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "validator"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da339118f018cc70ebf01fafc103360528aad53717e4bf311db929cb01cb9345"
-dependencies = [
- "idna",
- "once_cell",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "url",
- "validator_derive",
-]
-
-[[package]]
-name = "validator_derive"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76e88ea23b8f5e59230bff8a2f03c0ee0054a61d5b8343a38946bcd406fe624c"
-dependencies = [
- "darling",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "regex",
- "syn 2.0.53",
-]
-
-[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2063,12 +2005,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "want"
@@ -2106,7 +2042,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -2140,7 +2076,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/tests/rust-axum-relaxed/Cargo.toml
+++ b/tests/rust-axum-relaxed/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_repr = "0.1"
 regex = "1"
-validator = { version = "0.17.0", features = ["derive"] }
+garde = { version = "0.18.0", features = ["derive", "regex"] }
 once_cell = "1.18.0"
 chrono = { version = "0.4", features = ["serde"] }
 

--- a/tests/rust-axum-relaxed/spec/api/components/devices/schemas.yaml
+++ b/tests/rust-axum-relaxed/spec/api/components/devices/schemas.yaml
@@ -2,7 +2,7 @@ Device:
   additionalProperties: false
   type: object
   required:
-    - deviceId 
+    - deviceId
     - deviceClassType
     - remoteId
   properties:
@@ -19,6 +19,13 @@ Device:
       format: date-time
     ratio:
       type: number
+    features:
+      type: array
+      minItems: 1
+      items:
+        type: string
+        minLength: 1
+        description: single feature of device
     custom:
       type: array
       items:

--- a/tests/rust-axum-relaxed/src/main.rs
+++ b/tests/rust-axum-relaxed/src/main.rs
@@ -73,6 +73,7 @@ mod handler {
                     None,
                     None,
                     None,
+                    None,
                 )],
             }));
         }
@@ -101,6 +102,7 @@ mod handler {
                     None,
                     None,
                     None,
+                    None,
                 )],
             }));
         } else if query.page.unwrap_or(0) == 2 {
@@ -113,6 +115,7 @@ mod handler {
                     "138f5d31-4feb-4765-88ad-989dff706b53".to_string(),
                     api::model::DeviceDeviceClassTypeVariant::DeviceDeviceClassType10,
                     uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"),
+                    None,
                     None,
                     None,
                     None,
@@ -151,6 +154,7 @@ mod handler {
                 "test".to_string(),
                 api::model::DeviceDeviceClassTypeVariant::DeviceDeviceClassType10,
                 uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"),
+                None,
                 None,
                 None,
                 None,
@@ -561,6 +565,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             ))
             .await;
 
@@ -595,6 +600,7 @@ mod tests {
                 "conflict".to_string(),
                 super::client::devices::model::DeviceDeviceClassTypeVariant::DeviceDeviceClassType15,
                 uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"),
+                None,
                 None,
                 None,
                 None,
@@ -703,6 +709,7 @@ mod tests {
                 remote_id: uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"),
                 updated_at: None,
                 ratio: Some(10f64),
+                features: None,
                 custom: None,
                 limited_text: None,
             }
@@ -729,6 +736,7 @@ mod tests {
                 remote_id: uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"),
                 updated_at: Some(Utc.with_ymd_and_hms(2014, 7, 8, 9, 10, 11).unwrap()),
                 ratio: Some(10f64),
+                features: None,
                 custom: None,
                 limited_text: None,
             }
@@ -756,6 +764,7 @@ mod tests {
                 remote_id: uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"),
                 updated_at: Some(Utc.with_ymd_and_hms(2014, 7, 8, 9, 10, 11).unwrap()),
                 ratio: Some(10f64),
+                features: None,
                 custom: Some(Coordinates(0.5f64, 0.8f64)),
                 limited_text: None,
             }
@@ -784,6 +793,7 @@ mod tests {
                 remote_id: uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"),
                 updated_at: None,
                 ratio: Some(10f64),
+                features: Some(vec!["usb".to_string()]),
                 custom: None,
                 limited_text: None,
             }

--- a/tests/rust-axum-relaxed/src/main.rs
+++ b/tests/rust-axum-relaxed/src/main.rs
@@ -31,7 +31,7 @@ mod handler {
 
     use axum::extract::{Json, Path, State};
     use uuid::uuid;
-    use validator::Validate;
+    use garde::Validate;
 
     use crate::{api, AppState, api::qs::Query};
 
@@ -181,7 +181,7 @@ mod handler {
         State(state): State<AppState>,
         Json(request): Json<api::model::Device>,
     ) -> api::endpoint::DeviceCreateV1Response {
-        if let Err(_) = request.validate() {
+        if let Err(_) = request.validate(&()) {
             return api::endpoint::DeviceCreateV1Response::Status400(
                 api::model::CreateDevice400Response::new(
                     api::model::CreateDevice400ResponseError::new(

--- a/tests/rust-axum/Cargo.lock
+++ b/tests/rust-axum/Cargo.lock
@@ -114,7 +114,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
 ]
 
 [[package]]
@@ -125,7 +125,7 @@ checksum = "461abc97219de0eaaf81fe3ef974a540158f3d079c2ab200f891f1a2ef201e85"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
 ]
 
 [[package]]
@@ -244,7 +244,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
 ]
 
 [[package]]
@@ -293,6 +293,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
+name = "castaway"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a17ed5635fc8536268e5d4de1e22e81ac34419e5f052d4d51f4e01dcc263fcc"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +335,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "compact_str"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,41 +377,6 @@ name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
-
-[[package]]
-name = "darling"
-version = "0.20.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.53",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
-dependencies = [
- "darling_core",
- "quote",
- "syn 2.0.53",
-]
 
 [[package]]
 name = "either"
@@ -537,7 +524,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
 ]
 
 [[package]]
@@ -568,6 +555,31 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "garde"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fa8fb3ffe035745c6194540b2064b2fe275f32367fbb4eb026024b7921e2e5"
+dependencies = [
+ "compact_str",
+ "garde_derive",
+ "once_cell",
+ "regex",
+ "smallvec",
+]
+
+[[package]]
+name = "garde_derive"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf62650515830c41553b72bd49ec20fb120226f9277c7f2847f071cf998325b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
 ]
 
 [[package]]
@@ -838,12 +850,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1060,7 +1066,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
 ]
 
 [[package]]
@@ -1214,7 +1220,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
 ]
 
 [[package]]
@@ -1240,30 +1246,6 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -1294,7 +1276,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
 ]
 
 [[package]]
@@ -1473,6 +1455,7 @@ dependencies = [
  "env_logger",
  "futures",
  "futures-core",
+ "garde",
  "log",
  "once_cell",
  "opentelemetry",
@@ -1490,7 +1473,6 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
- "validator",
 ]
 
 [[package]]
@@ -1539,7 +1521,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
 ]
 
 [[package]]
@@ -1582,7 +1564,7 @@ checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
 ]
 
 [[package]]
@@ -1641,20 +1623,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.10.0"
+name = "static_assertions"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "unicode-ident",
-]
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
@@ -1723,7 +1695,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
 ]
 
 [[package]]
@@ -1788,7 +1760,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
 ]
 
 [[package]]
@@ -1905,7 +1877,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
 ]
 
 [[package]]
@@ -2023,36 +1995,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "validator"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da339118f018cc70ebf01fafc103360528aad53717e4bf311db929cb01cb9345"
-dependencies = [
- "idna",
- "once_cell",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "url",
- "validator_derive",
-]
-
-[[package]]
-name = "validator_derive"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76e88ea23b8f5e59230bff8a2f03c0ee0054a61d5b8343a38946bcd406fe624c"
-dependencies = [
- "darling",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "regex",
- "syn 2.0.53",
-]
-
-[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2063,12 +2005,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "want"
@@ -2106,7 +2042,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -2140,7 +2076,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/tests/rust-axum/Cargo.toml
+++ b/tests/rust-axum/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_repr = "0.1"
 regex = "1"
-validator = { version = "0.17.0", features = ["derive"] }
+garde = { version = "0.18.0", features = ["derive", "regex"] }
 once_cell = "1.18.0"
 chrono = { version = "0.4", features = ["serde"] }
 

--- a/tests/rust-axum/spec/api/components/devices/parameters.yaml
+++ b/tests/rust-axum/spec/api/components/devices/parameters.yaml
@@ -1,5 +1,5 @@
 deviceIdPath:
-  in: path 
+  in: path
   name: deviceId
   required: true
   schema:

--- a/tests/rust-axum/spec/api/components/devices/schemas.yaml
+++ b/tests/rust-axum/spec/api/components/devices/schemas.yaml
@@ -2,7 +2,7 @@ Device:
   additionalProperties: false
   type: object
   required:
-    - deviceId 
+    - deviceId
     - deviceClassType
     - remoteId
   properties:
@@ -19,6 +19,13 @@ Device:
       format: date-time
     ratio:
       type: number
+    features:
+      type: array
+      minItems: 1
+      items:
+        type: string
+        minLength: 1
+        description: single feature of device
     custom:
       type: array
       items:

--- a/tests/rust-axum/src/main.rs
+++ b/tests/rust-axum/src/main.rs
@@ -32,7 +32,7 @@ mod handler {
 
     use axum::extract::State;
     use uuid::uuid;
-    use validator::Validate;
+    use garde::Validate;
 
     use crate::{api, AppState};
 
@@ -183,7 +183,7 @@ mod handler {
         request: api::model::Device,
         State(state): State<AppState>,
     ) -> api::endpoint::DeviceCreateV1Response {
-        if let Err(_) = request.validate() {
+        if let Err(_) = request.validate(&()) {
             return api::endpoint::DeviceCreateV1Response::Status400(
                 api::model::CreateDevice400Response::new(
                     api::model::CreateDevice400ResponseError::new(

--- a/tests/rust-axum/src/main.rs
+++ b/tests/rust-axum/src/main.rs
@@ -74,6 +74,7 @@ mod handler {
                     None,
                     None,
                     None,
+                    None,
                 )],
             });
         }
@@ -102,6 +103,7 @@ mod handler {
                     None,
                     None,
                     None,
+                    None,
                 )],
             });
         } else if query.page.unwrap_or(0) == 2 {
@@ -114,6 +116,7 @@ mod handler {
                     "138f5d31-4feb-4765-88ad-989dff706b53".to_string(),
                     api::model::DeviceDeviceClassTypeVariant::DeviceDeviceClassType10,
                     uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"),
+                    None,
                     None,
                     None,
                     None,
@@ -152,6 +155,7 @@ mod handler {
                 "test".to_string(),
                 api::model::DeviceDeviceClassTypeVariant::DeviceDeviceClassType10,
                 uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"),
+                None,
                 None,
                 None,
                 None,
@@ -566,6 +570,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             ))
             .await;
 
@@ -600,6 +605,7 @@ mod tests {
                 "conflict".to_string(),
                 super::client::devices::model::DeviceDeviceClassTypeVariant::DeviceDeviceClassType15,
                 uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"),
+                None,
                 None,
                 None,
                 None,
@@ -708,6 +714,7 @@ mod tests {
                 remote_id: uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"),
                 updated_at: None,
                 ratio: Some(10f64),
+                features: None,
                 custom: None,
                 limited_text: None,
             }
@@ -734,6 +741,7 @@ mod tests {
                 remote_id: uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"),
                 updated_at: Some(Utc.with_ymd_and_hms(2014, 7, 8, 9, 10, 11).unwrap()),
                 ratio: Some(10f64),
+                features: None,
                 custom: None,
                 limited_text: None,
             }
@@ -761,6 +769,7 @@ mod tests {
                 remote_id: uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"),
                 updated_at: Some(Utc.with_ymd_and_hms(2014, 7, 8, 9, 10, 11).unwrap()),
                 ratio: Some(10f64),
+                features: None,
                 custom: Some(Coordinates(0.5f64, 0.8f64)),
                 limited_text: None,
             }
@@ -789,6 +798,7 @@ mod tests {
                 remote_id: uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8"),
                 updated_at: None,
                 ratio: Some(10f64),
+                features: Some(vec!["usb".to_string()]),
                 custom: None,
                 limited_text: None,
             }

--- a/tests/rust/Cargo.lock
+++ b/tests/rust/Cargo.lock
@@ -671,6 +671,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "castaway"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a17ed5635fc8536268e5d4de1e22e81ac34419e5f052d4d51f4e01dcc263fcc"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,6 +744,19 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "compact_str"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -873,41 +895,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "darling"
-version = "0.20.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.16",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
-dependencies = [
- "darling_core",
- "quote",
- "syn 2.0.16",
 ]
 
 [[package]]
@@ -1220,6 +1207,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "garde"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fa8fb3ffe035745c6194540b2064b2fe275f32367fbb4eb026024b7921e2e5"
+dependencies = [
+ "compact_str",
+ "garde_derive",
+ "once_cell",
+ "regex",
+ "smallvec",
+]
+
+[[package]]
+name = "garde_derive"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf62650515830c41553b72bd49ec20fb120226f9277c7f2847f071cf998325b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.16",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1409,26 +1421,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
-name = "idna"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -2009,30 +2005,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2328,6 +2300,7 @@ dependencies = [
  "env_logger",
  "futures",
  "futures-core",
+ "garde",
  "lapin",
  "log",
  "once_cell",
@@ -2343,7 +2316,6 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
- "validator",
 ]
 
 [[package]]
@@ -2502,9 +2474,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
@@ -2526,10 +2498,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.10.0"
+name = "static_assertions"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "subtle"
@@ -2944,7 +2916,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
- "idna 0.3.0",
+ "idna",
  "percent-encoding",
 ]
 
@@ -2959,36 +2931,6 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
-name = "validator"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da339118f018cc70ebf01fafc103360528aad53717e4bf311db929cb01cb9345"
-dependencies = [
- "idna 0.5.0",
- "once_cell",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "url",
- "validator_derive",
-]
-
-[[package]]
-name = "validator_derive"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76e88ea23b8f5e59230bff8a2f03c0ee0054a61d5b8343a38946bcd406fe624c"
-dependencies = [
- "darling",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "regex",
- "syn 2.0.16",
-]
 
 [[package]]
 name = "valuable"

--- a/tests/rust/Cargo.toml
+++ b/tests/rust/Cargo.toml
@@ -18,7 +18,7 @@ serde = "1.0"
 serde_json = "1.0"
 serde_repr = "0.1"
 regex = "1"
-validator = { version = "0.17.0", features = ["derive"] }
+garde = { version = "0.18.0", features = ["derive", "regex"] }
 once_cell = "1.18.0"
 
 # messages


### PR DESCRIPTION
keats/validator has some problems from the beginning...
in version 0.17 it sometimes not validate nested structs
in version 0.18 it has problems with Option<Option<T>>
and in all version it has problems with validating vector items

garde should fix all of this, but this PR is only to replace validator with garde, no extra validation