### PR TITLE
feat: support "date" format alongside "date-time" in templates

### DIFF
--- a/rust/_common/macros.j2
+++ b/rust/_common/macros.j2
@@ -140,7 +140,7 @@
 {% elif property.type == "string" %}
     {% if property.validation and property.validation.format and property.validation.format == "uuid" %}
     uuid::Uuid
-    {% elif property.validation and property.validation.format and property.validation.format == "date-time" %}
+    {% elif property.validation and property.validation.format and property.validation.format in ["date-time", "date"] %}
     DateTime<Utc>
     {% else %}
     String

--- a/rust/_common/models.j2
+++ b/rust/_common/models.j2
@@ -12,7 +12,7 @@ use once_cell::sync::Lazy;{% endif %}
 {% if formats is containing("decimal") %}
 use rust_decimal::Decimal;
 {% endif %}
-{% if formats is containing("date-time") %}
+{% if formats is containing("date-time") or formats is containing("date") %}
 use chrono::{DateTime, Utc};
 {% endif %}
 

--- a/rust/client/endpoints.j2
+++ b/rust/client/endpoints.j2
@@ -8,7 +8,7 @@ use reqwest::header::{HeaderName, HeaderValue};
 use super::{ClientError, ApiError, ResponseProcessingError};
 use std::future::Future;
 use std::pin::Pin;
-{% if formats is containing("date-time") -%}
+{% if formats is containing("date-time") or formats is containing("date") -%}
     use chrono::{DateTime, Utc};
 {% endif %}
 

--- a/rust/rabbitmq/models-message.j2
+++ b/rust/rabbitmq/models-message.j2
@@ -2,7 +2,7 @@
 {% extends "models.j2" %}
 {% block use %}
 use amq_protocol_types::{AMQPValue, LongString, ShortString};
-{% if formats is not containing("date-time") %}
+{% if formats is not containing("date-time") or formats is containing("date") %}
 use chrono::{DateTime, Utc};
 {% endif %}
 use lapin::types::FieldTable;


### PR DESCRIPTION
Updated templates to handle the "date" format in addition to "date-time" for proper type mapping and imports. This ensures compatibility with schemas using the "date" format and prevents potential handling issues.