### PR TITLE
fix: invalid rust code produced

### DIFF
--- a/rust/_common/macros.j2
+++ b/rust/_common/macros.j2
@@ -126,7 +126,7 @@
             #[garde(skip)]
         {%- endif %}
     {%- endif %}
-{% endfilter %}{% endmacro model_validation %}
+{% endfilter %}{% endmacro enum_validation %}
 
 {% macro type(property, ns="") %}{% filter nospaces %}
 {% if property.nullable %}Option<{% endif %}
@@ -239,9 +239,11 @@
 {% endfilter %}{% endmacro model_to_string %}
 
 {% macro need_nested_validation(property) %}{% filter nospaces %}
-    {% if property.model and property.model.type == "array" and property.model.model %}
-        {{ self::need_nested_validation(property = property.model.model) }}
-    {% elif property.type == "map" and property.model.type == "any" %}
+    {% if property.type == "array" and property.model %}
+        {{ self::need_nested_validation(property = property.model) }}
+    {% elif property.type == "map" and property.model.type in [
+        "string", "number", "integer", "boolean", "bool", "null", "enum", "any"
+    ] %}
         0
     {% elif property.type != "enum" and not property.x.type and property.model and property.model.type not in [
         "string", "number", "integer", "boolean", "bool", "null", "enum"] %}

--- a/rust/_common/models.j2
+++ b/rust/_common/models.j2
@@ -1,5 +1,6 @@
 {% import "macros.j2" as m -%}
 {% import "extensions.j2" as e -%}
+{% set_global emptyVariantName = options.emptyVariantName | default(value = "EmptyVariant") %}
 {# if wrappers include #}
 {{ m::do_not_modify() }}
 use serde::{Serialize, Deserialize, Deserializer};
@@ -63,7 +64,10 @@ impl {{ m::model_name(name = model.object.name) }} { {# if sort required first #
 {%- endif %}
 pub enum {{ m::model_name(name = model.enum.name) }}Variant {
     {% for option in model.enum.options -%}
-    {% if option == option | when_numeric(prefix="n") | pascalcase -%}
+    {%- if option == "" -%}
+    #[serde(rename = "")]
+    {{ emptyVariantName }},
+    {%- elif option == option | when_numeric(prefix="n") | pascalcase -%}
     {{ option }},
     {%- elif model.enum.type == "number" %}
     {{ m::enum_variant(name = option, base = m::model_name(name = model.enum.name) ) }} = {{ option }},
@@ -82,7 +86,9 @@ impl std::string::ToString for {{ m::model_name(name = model.enum.name) }}Varian
     fn to_string(&self) -> String {
         match self {
             {%- for option in model.enum.options %}
-            Self::{%- if option == option | when_numeric(prefix="n") | pascalcase -%}
+            Self::{%- if option == "" -%}
+                {{ emptyVariantName }}
+            {%- elif option == option | when_numeric(prefix="n") | pascalcase -%}
             {{ option }}
             {%- elif model.enum.type == "number" -%}
             {{ m::enum_variant(name = option, base = m::model_name(name = model.enum.name) ) }}
@@ -103,7 +109,9 @@ impl std::str::FromStr for {{ m::model_name(name = model.enum.name) }}Variant {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             {%- for option in model.enum.options %}
-            "{{ option }}" => Ok(Self::{%- if option == option | when_numeric(prefix="n") | pascalcase -%}
+            "{{ option }}" => Ok(Self::{%- if option == "" -%}
+                {{ emptyVariantName }}
+            {%- elif option == option | when_numeric(prefix="n") | pascalcase -%}
             {{ option }}
             {%- elif model.enum.type == "number" -%}
             {{ m::enum_variant(name = option, base = m::model_name(name = model.enum.name) ) }}

--- a/rust/client/endpoints.j2
+++ b/rust/client/endpoints.j2
@@ -61,7 +61,7 @@ impl ApiError for {{ endpoint.operation | pascalcase }}Error {
 				},
 				{% else %}
 					{% if not response.models %}
-					Some(Self::Error{{ response.statusCode }}),
+					Ok(Self::Error{{ response.statusCode }}()),
 					{% else %}
 					{% if response.models.default.contentType == "text/plain" and response.models.default.model.type == "string" %}
 					response.text()


### PR DESCRIPTION
I encountered some problems while running templates with schema-tools against docker openapi description.

In case you want see it there is my script to download and convert docker specs to openapi v3 format

Requirements :
- install yq
- make a folder and inside git clone https://github.com/kstasik/schema-tools-templates && git clone https://github.com/kstasik/schema-tools
- save this script in the current folder

```
#!/bin/sh

version=$1

if [ -z "$version" ]; then
  echo "Usage: $0 <version>"
  exit 1
fi

mkdir -p resources

curl https://docs.docker.com/reference/api/engine/version/"$version".yaml -o resources/"$version".yaml

yq -p yaml -o json "resources/$version.yaml" >"resources/$version.json"

curl 'https://converter.swagger.io/api/convert' \
  -o resources/"$version-v3".json \
  -H 'authority: converter.swagger.io' \
  -H 'accept: application/json' \
  -H 'accept-language: fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7' \
  -H 'cache-control: no-cache' \
  -H 'content-type: application/json' \
  -H 'origin: https://editor.swagger.io' \
  -H 'pragma: no-cache' \
  -H 'priority: u=1, i' \
  -H 'referer: https://editor.swagger.io/' \
  -H 'sec-ch-ua: "Chromium";v="121", "Not A(Brand";v="99"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "macOS"' \
  -H 'sec-fetch-dest: empty' \
  -H 'sec-fetch-mode: cors' \
  -H 'sec-fetch-site: same-site' \
  -H 'user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36' \
  --data-binary "@resources/$version.json" \
  --compressed

cd schema-tools

cargo run --frozen codegen openapi ../resources/"$version"-v3.json --target-dir ./out --template ../schema-tools-templates/rust/client/ --template ../schema-tools-templates/rust/_common -o namespace=client -o name=DockerFetcher --format 'rustfmt --edition 2021'
```

I comment on changes the reason for each