### PR TITLE
feat: add handling for "*" enum option in code generation

### DIFF
--- a/rust/_common/models.j2
+++ b/rust/_common/models.j2
@@ -63,13 +63,17 @@ impl {{ m::model_name(name = model.object.name) }} { {# if sort required first #
 {%- endif %}
 pub enum {{ m::model_name(name = model.enum.name) }}Variant {
     {% for option in model.enum.options -%}
-    {% if option == option | when_numeric(prefix="n") | pascalcase -%}
+    {% if option == "*" %}
+    #[serde(rename = "{{ option }}")]
+    {%- set a = 'SignStar' %}
+    {{ m::enum_variant(name = a, base = m::model_name(name = a) ) }},
+    {% elif option == option | when_numeric(prefix="n") | pascalcase -%}
     {{ option }},
     {%- elif model.enum.type == "number" %}
     {{ m::enum_variant(name = option, base = m::model_name(name = model.enum.name) ) }} = {{ option }},
     {%- elif option is matching("^[\d]+") %}
     #[serde(rename = "{{ option }}")]
-    {%set a = 'Code' ~ option %}
+    {% set a = 'Code' ~ option %}
     {{ m::enum_variant(name = a, base = m::model_name(name = a)) }},
     {%- else %}
     #[serde(rename = "{{ option }}")]
@@ -82,7 +86,10 @@ impl std::string::ToString for {{ m::model_name(name = model.enum.name) }}Varian
     fn to_string(&self) -> String {
         match self {
             {%- for option in model.enum.options %}
-            Self::{%- if option == option | when_numeric(prefix="n") | pascalcase -%}
+            Self::{%- if option == "*" -%}
+            {%- set a = 'SignStar' -%}
+            {{- m::enum_variant(name = a, base = m::model_name(name = a) ) -}}
+            {%- elif option == option | when_numeric(prefix="n") | pascalcase -%}
             {{ option }}
             {%- elif model.enum.type == "number" -%}
             {{ m::enum_variant(name = option, base = m::model_name(name = model.enum.name) ) }}
@@ -103,7 +110,10 @@ impl std::str::FromStr for {{ m::model_name(name = model.enum.name) }}Variant {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             {%- for option in model.enum.options %}
-            "{{ option }}" => Ok(Self::{%- if option == option | when_numeric(prefix="n") | pascalcase -%}
+            "{{ option }}" => Ok(Self::{%- if option == "*" %}
+            {%- set a = 'SignStar' %}
+            {{- m::enum_variant(name = a, base = m::model_name(name = a) ) }}
+            {%- elif option == option | when_numeric(prefix="n") | pascalcase -%}
             {{ option }}
             {%- elif model.enum.type == "number" -%}
             {{ m::enum_variant(name = option, base = m::model_name(name = model.enum.name) ) }}


### PR DESCRIPTION
Updated the enum generation logic to handle the "*" (SignStar) variant consistently across model definitions, string conversions, and match cases. This ensures correct serialization and deserialization for the new special case.