### PR TITLE
fix(macros): handle "array" type in nested validation check

### DIFF
--- a/rust/_common/macros.j2
+++ b/rust/_common/macros.j2
@@ -241,7 +241,7 @@
 {% macro need_nested_validation(property) %}{% filter nospaces %}
     {% if property.model and property.model.type == "array" and property.model.model %}
         {{ self::need_nested_validation(property = property.model.model) }}
-    {% elif property.type == "map" and property.model.type == "any" %}
+    {% elif property.type in ["map", "array"] and property.model.type == "any" %}
         0
     {% elif property.type != "enum" and not property.x.type and property.model and property.model.type not in [
         "string", "number", "integer", "boolean", "bool", "null", "enum"] %}


### PR DESCRIPTION
Updated the condition to account for "array" type alongside "map" when validating nested properties. This ensures the macro correctly handles these cases and improves consistency in type checks.