### PR TITLE
feature: remove empty new lines from models

### DIFF
--- a/rust/_common/models.j2
+++ b/rust/_common/models.j2
@@ -30,7 +30,7 @@ pub static {{ regexp.name | snakecase | upper }}: Lazy<Regex> = Lazy::new(|| { R
 #[derive(Deserialize, Serialize, Debug,{% if not options.skipValidate %} Validate,{% endif %} Clone{% if model.object.properties | filter(attribute="required", value=true) | length == 0 %}, Default{% endif %})]
 pub struct {{ m::model_name(name = model.object.name) }} {
     {%- set filtered_properties = model.object.properties | filter_not(attribute="type", value="const") %}
-    {% for property in filtered_properties %}
+    {% for property in filtered_properties -%}
     {{ m::model_validation(model = property, options = options) }}
     #[serde(rename = "{{ property.name }}"{% if not property.required and property.nullable %}, default, deserialize_with = "optional_nullable"{% elif not property.required %}, skip_serializing_if = "Option::is_none"{% endif %})]
     pub {{ m::property_name(name = property.name) }}: {% if not property.required %}Option<{% endif %}{{ m::type(property = property) }}{% if not property.required %}>{% endif %},
@@ -42,7 +42,7 @@ impl {{ m::model_name(name = model.object.name) }} {
         Self {
             {% for property in filtered_properties -%}
             {{ m::property_name(name = property.name) }},
-            {% endfor %}
+            {%- endfor %}
         }
     }
     {%- for property in model.object.properties | filter(attribute="type", value="const") -%}


### PR DESCRIPTION
In some clients, this was making a lot of empty lines causing linter to fail. Found 2 unclosed blocks that fixed our problem.