### PR TITLE
refactor: replace `once_cell::Lazy` with `std::sync::LazyLock` and re…

### DIFF
--- a/rust/_common/models.j2
+++ b/rust/_common/models.j2
@@ -7,7 +7,7 @@ use std::str::FromStr;
 use std::collections::BTreeMap;
 {% if not options.skipValidate %}use garde::Validate;
 use regex::Regex;
-use once_cell::sync::Lazy;{% endif %}
+use std::sync::LazyLock;{% endif %}
 {% block use %}{% endblock use %}
 
 {% if formats is containing("decimal") %}
@@ -18,11 +18,11 @@ use chrono::{DateTime, Utc};
 {% endif %}
 
 {% if not options.skipValidate %}
-pub static UUID: Lazy<Regex> = Lazy::new(|| { Regex::new(r"^\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b$").unwrap() });
-pub static FLOAT: Lazy<Regex> = Lazy::new(|| { Regex::new(r"^[0-9\.]+$").unwrap() });
+pub static UUID: LazyLock<Regex> = LazyLock::new(|| { Regex::new(r"^\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b$").unwrap() });
+pub static FLOAT: LazyLock<Regex> = LazyLock::new(|| { Regex::new(r"^[0-9\.]+$").unwrap() });
 {% for regexp in regexps -%}
-pub static {{ regexp.name | snakecase | upper }}: Lazy<Regex> = Lazy::new(|| { Regex::new(r"{{ regexp.pattern }}").unwrap() });
-{%- endfor %}
+pub static {{ regexp.name | snakecase | upper }}: LazyLock<Regex> = LazyLock::new(|| { Regex::new(r"{{ regexp.pattern }}").unwrap() });
+{% endfor -%}
 {% endif %}
 
 {% for model in models %}

--- a/tests/rust-axum-relaxed/Cargo.toml
+++ b/tests/rust-axum-relaxed/Cargo.toml
@@ -22,7 +22,6 @@ serde_json = "1.0"
 serde_repr = "0.1"
 regex = "1"
 garde = { version = "0.22.0", features = ["derive", "regex"] }
-once_cell = "1.20.2"
 chrono = { version = "0.4", features = ["serde"] }
 
 # tracing

--- a/tests/rust-axum/Cargo.toml
+++ b/tests/rust-axum/Cargo.toml
@@ -22,7 +22,6 @@ serde_json = "1.0"
 serde_repr = "0.1"
 regex = "1"
 garde = { version = "0.22.0", features = ["derive", "regex"] }
-once_cell = "1.20.2"
 chrono = { version = "0.4", features = ["serde"] }
 
 # tracing

--- a/tests/rust/Cargo.toml
+++ b/tests/rust/Cargo.toml
@@ -19,7 +19,6 @@ serde_json = "1.0"
 serde_repr = "0.1"
 regex = "1"
 garde = { version = "0.22.0", features = ["derive", "regex"] }
-once_cell = "1.20.2"
 
 # messages
 lapin = { version = "4.4.0" }


### PR DESCRIPTION
…move `once_cell` dependency

Updated regex static initializations to use `LazyLock` from the standard library. Removed `once_cell` from dependencies in affected `Cargo.toml` files.