### PR TITLE
feature: better error when consumer stream closed

### DIFF
--- a/rust/rabbitmq-tokio/consumer.j2
+++ b/rust/rabbitmq-tokio/consumer.j2
@@ -286,7 +286,7 @@ async fn consume_loop<D: Clone + Send + Sync + 'static>(
                     break LoopExit::StreamError;
                 }
                 None => {
-                    tracing::warn!(worker = id, "Stream closed");
+                    tracing::error!(worker = id, "Stream closed unexpectedly");
                     break LoopExit::StreamClosed;
                 }
             }

--- a/rust/rabbitmq-tokio/consumer.j2
+++ b/rust/rabbitmq-tokio/consumer.j2
@@ -248,6 +248,7 @@ async fn setup_channel(
         }
     };
 
+    tracing::info!(worker = id, queue = queue.as_ref(), "Connection established");
     *backoff = Duration::from_millis(500);
     Some(WorkerChannel { conn, stream })
 }


### PR DESCRIPTION
Log an error when consumer stream is closed, e.g when it can't connect to the queue.